### PR TITLE
feat: support KW COCO JSON alongside CSV in annotation pre-processing

### DIFF
--- a/routes/projects/mapKwCocoCsv.js
+++ b/routes/projects/mapKwCocoCsv.js
@@ -1,6 +1,7 @@
 const path = require('path');
 const fs = require('fs');
 const parseKwCocoCsv = require('../../utils/parseKwCocoCsv');
+const parseKwCocoJson = require('../../utils/parseKwCocoJson');
 const queries = require('../../queries/queries');
 const { Client } = require('../../queries/client');
 
@@ -14,19 +15,24 @@ async function mapKwCocoCsv(req, res) {
         }
 
         if (!req.files || Object.keys(req.files).length === 0) {
-            return res.status(400).json({ success: false, message: 'No CSV file was uploaded.' });
+            return res.status(400).json({ success: false, message: 'No annotation file was uploaded.' });
         }
 
-        const uploadedFile = req.files.kwcoco_csv || req.files.csv_file || req.files.upload_csv || Object.values(req.files)[0];
+        const uploadedFile = req.files.kwcoco_csv || req.files.kwcoco_json || req.files.csv_file
+            || req.files.json_file || req.files.upload_csv || req.files.upload_json || Object.values(req.files)[0];
         if (!uploadedFile) {
             return res.status(400).json({ success: false, message: 'Invalid file upload payload.' });
         }
 
-        const csvContent = uploadedFile.data ? uploadedFile.data.toString('utf8') : fs.readFileSync(uploadedFile.tempFilePath, 'utf8');
+        const fileContent = uploadedFile.data ? uploadedFile.data.toString('utf8') : fs.readFileSync(uploadedFile.tempFilePath, 'utf8');
 
-        const parsedAnnotations = parseKwCocoCsv(csvContent);
+        const ext = path.extname(uploadedFile.name || '').toLowerCase();
+        const trimmedContent = fileContent.trim();
+        const isJson = ext === '.json' || (ext !== '.csv' && (trimmedContent.startsWith('{') || trimmedContent.startsWith('[')));
+
+        const parsedAnnotations = isJson ? parseKwCocoJson(fileContent) : parseKwCocoCsv(fileContent);
         if (parsedAnnotations.length === 0) {
-            return res.status(400).json({ success: false, message: 'No valid KW COCO CSV annotations found in file.' });
+            return res.status(400).json({ success: false, message: 'No valid KW COCO annotations found in file.' });
         }
 
         const mainPath = path.join(__dirname, '..', '..', 'public', 'projects');

--- a/tests/integration/mapKwCocoCsv.test.js
+++ b/tests/integration/mapKwCocoCsv.test.js
@@ -48,7 +48,7 @@ describe('POST /api/projects/map-kwcoco-csv', () => {
         expect(res.body.message).toMatch(/Project name is required/i);
     });
 
-    test('returns 400 when no CSV file is uploaded', async () => {
+    test('returns 400 when no annotation file is uploaded', async () => {
         const res = await request(app)
             .post('/api/projects/map-kwcoco-csv')
             .field('PName', 'testproj')
@@ -56,7 +56,7 @@ describe('POST /api/projects/map-kwcoco-csv', () => {
 
         expect(res.statusCode).toBe(400);
         expect(res.body.success).toBe(false);
-        expect(res.body.message).toMatch(/No CSV file was uploaded/i);
+        expect(res.body.message).toMatch(/No annotation file was uploaded/i);
     });
 
     test('returns 404 when project path does not exist', async () => {
@@ -86,6 +86,35 @@ img2.jpg,shark,30,40,80,120`;
             .field('PName', 'testproj')
             .field('Admin', 'admin')
             .attach('kwcoco_csv', csvPath);
+
+        expect(res.statusCode).toBe(200);
+        expect(res.body.success).toBe(true);
+        expect(res.body.labelsInserted).toBe(2);
+    });
+
+    test('successfully maps KW COCO JSON annotations', async () => {
+        const jsonContent = JSON.stringify({
+            images: [
+                { id: 1, file_name: 'img1.jpg' },
+                { id: 2, file_name: 'img2.jpg' }
+            ],
+            annotations: [
+                { id: 1, image_id: 1, category_id: 1, bbox: [10, 20, 90, 130] },
+                { id: 2, image_id: 2, category_id: 2, bbox: [30, 40, 50, 80] }
+            ],
+            categories: [
+                { id: 1, name: 'dolphin' },
+                { id: 2, name: 'shark' }
+            ]
+        });
+        const jsonPath = path.join(tmpDir, 'test.json');
+        fs.writeFileSync(jsonPath, jsonContent);
+
+        const res = await request(app)
+            .post('/api/projects/map-kwcoco-csv')
+            .field('PName', 'testproj')
+            .field('Admin', 'admin')
+            .attach('kwcoco_json', jsonPath);
 
         expect(res.statusCode).toBe(200);
         expect(res.body.success).toBe(true);

--- a/tests/unit/parseKwCocoJson.test.js
+++ b/tests/unit/parseKwCocoJson.test.js
@@ -1,0 +1,64 @@
+const parseKwCocoJson = require('../../utils/parseKwCocoJson');
+
+describe('parseKwCocoJson', () => {
+    test('returns empty array for invalid or empty input', () => {
+        expect(parseKwCocoJson(null)).toEqual([]);
+        expect(parseKwCocoJson('')).toEqual([]);
+        expect(parseKwCocoJson('not json')).toEqual([]);
+        expect(parseKwCocoJson('{}')).toEqual([]);
+    });
+
+    test('parses standard COCO-style JSON with images/annotations/categories', () => {
+        const json = JSON.stringify({
+            images: [
+                { id: 1, file_name: 'image1.jpg' },
+                { id: 2, file_name: 'path/to/image2.png' }
+            ],
+            annotations: [
+                { id: 1, image_id: 1, category_id: 10, bbox: [10, 20, 90, 130] },
+                { id: 2, image_id: 2, category_id: 11, bbox: [50, 60, 150, 200] }
+            ],
+            categories: [
+                { id: 10, name: 'dolphin' },
+                { id: 11, name: 'blue whale' }
+            ]
+        });
+
+        const result = parseKwCocoJson(json);
+        expect(result).toEqual([
+            { filename: 'image1.jpg', className: 'dolphin', x: 10, y: 20, w: 90, h: 130 },
+            { filename: 'image2.png', className: 'blue_whale', x: 50, y: 60, w: 150, h: 200 }
+        ]);
+    });
+
+    test('skips annotations referencing unknown images or categories', () => {
+        const json = JSON.stringify({
+            images: [{ id: 1, file_name: 'good.jpg' }],
+            annotations: [
+                { id: 1, image_id: 1, category_id: 5, bbox: [10, 10, 20, 20] },
+                { id: 2, image_id: 999, category_id: 5, bbox: [10, 10, 20, 20] },
+                { id: 3, image_id: 1, category_id: 999, bbox: [10, 10, 20, 20] }
+            ],
+            categories: [{ id: 5, name: 'fish' }]
+        });
+
+        const result = parseKwCocoJson(json);
+        expect(result).toEqual([
+            { filename: 'good.jpg', className: 'fish', x: 10, y: 10, w: 20, h: 20 }
+        ]);
+    });
+
+    test('ignores annotations with invalid or non-positive bbox dimensions', () => {
+        const json = JSON.stringify({
+            images: [{ id: 1, file_name: 'img.jpg' }],
+            annotations: [
+                { id: 1, image_id: 1, category_id: 1, bbox: [0, 0, 0, 0] },
+                { id: 2, image_id: 1, category_id: 1, bbox: ['a', 'b', 'c', 'd'] },
+                { id: 3, image_id: 1, category_id: 1, bbox: [1, 2, 3] }
+            ],
+            categories: [{ id: 1, name: 'shark' }]
+        });
+
+        expect(parseKwCocoJson(json)).toEqual([]);
+    });
+});

--- a/utils/parseKwCocoJson.js
+++ b/utils/parseKwCocoJson.js
@@ -1,0 +1,92 @@
+const path = require('path');
+
+/**
+ * Parses KW COCO / COCO-style JSON annotation content into the same
+ * {filename, className, x, y, w, h} shape produced by parseKwCocoCsv, so both
+ * formats can feed the same downstream label-import pipeline.
+ *
+ * Expects the standard COCO structure: {images: [...], annotations: [...], categories: [...]}
+ * with annotations referencing images/categories by id and bbox as [x, y, w, h].
+ *
+ * @param {string} jsonContent - Raw JSON string content
+ * @returns {Array<{filename: string, className: string, x: number, y: number, w: number, h: number}>} Parsed annotation objects
+ */
+function parseKwCocoJson(jsonContent) {
+    if (!jsonContent || typeof jsonContent !== 'string') {
+        return [];
+    }
+
+    let data;
+    try {
+        data = JSON.parse(jsonContent);
+    } catch (err) {
+        return [];
+    }
+
+    if (!data || typeof data !== 'object') {
+        return [];
+    }
+
+    const images = Array.isArray(data.images) ? data.images : [];
+    const annotations = Array.isArray(data.annotations) ? data.annotations : [];
+    const categories = Array.isArray(data.categories) ? data.categories : [];
+
+    if (images.length === 0 || annotations.length === 0) {
+        return [];
+    }
+
+    const imageIdToFilename = new Map();
+    for (const img of images) {
+        if (!img || img.id == null) continue;
+        const rawName = img.file_name || img.filename || img.name;
+        if (!rawName) continue;
+        imageIdToFilename.set(img.id, path.basename(String(rawName).replace(/\\/g, '/')));
+    }
+
+    const categoryIdToName = new Map();
+    for (const cat of categories) {
+        if (!cat || cat.id == null) continue;
+        const rawName = cat.name || cat.category_name;
+        if (!rawName) continue;
+        categoryIdToName.set(cat.id, String(rawName).replace(/\s+/g, '_'));
+    }
+
+    const results = [];
+
+    for (const ann of annotations) {
+        if (!ann) continue;
+
+        const filename = imageIdToFilename.get(ann.image_id);
+        if (!filename) continue;
+
+        const className = categoryIdToName.get(ann.category_id);
+        if (!className) continue;
+
+        const bbox = ann.bbox;
+        if (!Array.isArray(bbox) || bbox.length < 4) continue;
+
+        const xVal = parseFloat(bbox[0]);
+        const yVal = parseFloat(bbox[1]);
+        const wVal = parseFloat(bbox[2]);
+        const hVal = parseFloat(bbox[3]);
+
+        if (isNaN(xVal) || isNaN(yVal) || isNaN(wVal) || isNaN(hVal)) {
+            continue;
+        }
+
+        const x = Math.round(xVal);
+        const y = Math.round(yVal);
+        const w = Math.round(wVal);
+        const h = Math.round(hVal);
+
+        if (w <= 0 || h <= 0) {
+            continue;
+        }
+
+        results.push({ filename, className, x, y, w, h });
+    }
+
+    return results;
+}
+
+module.exports = parseKwCocoJson;

--- a/views/settings/projSettings.ejs
+++ b/views/settings/projSettings.ejs
@@ -95,18 +95,18 @@
     <hr>
     <div class="mb-3">
         <h3>
-            Pre-Processing: Map KW COCO CSV Annotations
+            Pre-Processing: Map KW COCO Annotations
         </h3>
         <p>
-            Upload a `.csv` annotation file (KW COCO format) to map bounding box labels directly to project images.
+            Upload a `.csv` or `.json` annotation file (KW COCO format) to map bounding box labels directly to project images.
         </p>
         <form action="/api/projects/map-kwcoco-csv" method="POST" enctype="multipart/form-data" id="mapKwCocoCsvForm">
             <input type="hidden" name="PName" value="<%= PName %>">
             <input type="hidden" name="Admin" value="<%= Admin %>">
             <input type="hidden" name="IDX" value="<%= IDX %>">
             <div class="mb-3">
-                <label for="kwcoco_csv" class="form-label">Upload KW COCO CSV File (.csv)</label>
-                <input id="kwcoco_csv" name="kwcoco_csv" aria-label="Upload KW COCO CSV annotation file" type="file" accept=".csv" class="form-control" required>
+                <label for="kwcoco_csv" class="form-label">Upload KW COCO Annotation File (.csv or .json)</label>
+                <input id="kwcoco_csv" name="kwcoco_csv" aria-label="Upload KW COCO annotation file" type="file" accept=".csv,.json" class="form-control" required>
             </div>
             <div>
                 <% if(user == Admin) { %>


### PR DESCRIPTION
Adds a JSON parser (images/annotations/categories -> bbox records) and dispatches by file extension/content sniffing in the existing map-kwcoco-csv route so uploads of either .csv or .json are handled by the same endpoint.