### PR TITLE
fix: use .rows when reading Client.all() results in mapKwCocoCsv

### DIFF
--- a/routes/projects/mapKwCocoCsv.js
+++ b/routes/projects/mapKwCocoCsv.js
@@ -55,7 +55,8 @@ async function mapKwCocoCsv(req, res) {
         await queries.project.migrateProjectDb(projectPath);
 
         // 1. Ensure all referenced classes exist in Classes table
-        const existingClassRows = await queries.project.getAllClasses(projectPath) || [];
+        const existingClassResult = await queries.project.getAllClasses(projectPath);
+        const existingClassRows = existingClassResult?.rows || [];
         const existingClassSet = new Set(existingClassRows.map(c => c.CName));
 
         const uniqueClasses = new Set(parsedAnnotations.map(a => a.className));
@@ -70,7 +71,8 @@ async function mapKwCocoCsv(req, res) {
         }
 
         // 2. Ensure referenced images exist in Images table
-        const existingImageRows = await queries.project.getAllImages(projectPath) || [];
+        const existingImageResult = await queries.project.getAllImages(projectPath);
+        const existingImageRows = existingImageResult?.rows || [];
         const existingImageSet = new Set(existingImageRows.map(i => i.IName));
 
         const uniqueImages = new Set(parsedAnnotations.map(a => a.filename));
@@ -86,9 +88,10 @@ async function mapKwCocoCsv(req, res) {
 
         // 3. Get current max LID in Labels table
         const maxLidResult = await queries.project.getMaxLabelId(projectPath);
+        const maxLidRows = maxLidResult?.rows || [];
         let nextLid = 1;
-        if (maxLidResult && maxLidResult.length > 0 && maxLidResult[0].LID) {
-            nextLid = maxLidResult[0].LID + 1;
+        if (maxLidRows.length > 0 && maxLidRows[0].LID) {
+            nextLid = maxLidRows[0].LID + 1;
         }
 
         // 4. Insert labels

--- a/tests/integration/mapKwCocoCsv.test.js
+++ b/tests/integration/mapKwCocoCsv.test.js
@@ -19,13 +19,13 @@ describe('POST /api/projects/map-kwcoco-csv', () => {
         const mockClient = {
             open: jest.fn(),
             all: jest.fn().mockImplementation((sql) => {
-                if (sql.includes('Classes')) return Promise.resolve([]);
-                if (sql.includes('Images')) return Promise.resolve([]);
-                if (sql.includes('Labels')) return Promise.resolve([]);
-                return Promise.resolve([]);
+                if (sql.includes('Classes')) return Promise.resolve({ success: true, rows: [] });
+                if (sql.includes('Images')) return Promise.resolve({ success: true, rows: [] });
+                if (sql.includes('Labels')) return Promise.resolve({ success: true, rows: [] });
+                return Promise.resolve({ success: true, rows: [] });
             }),
-            get: jest.fn().mockResolvedValue(null),
-            run: jest.fn().mockResolvedValue({ changes: 1 }),
+            get: jest.fn().mockResolvedValue({ success: true, row: null }),
+            run: jest.fn().mockResolvedValue({ success: true, changes: 1, lastID: 1 }),
         };
 
         global.projectDbClients = {


### PR DESCRIPTION
getAllClasses/getAllImages/getMaxLabelId resolve to {success, rows} (matching queries/client.js's db.all()/db.get() contract used elsewhere, e.g. routes/inference/yoloInference.js), not a bare array, so existingClassRows.map threw at runtime. The integration test mock returned plain arrays instead of the real {rows: [...]} shape, which is why 14/14 passed despite the bug; the mock now matches the real client contract.