### PR TITLE
Add Unlabeled as a selectable pseudo-class for training

### DIFF
--- a/queries/images/images.js
+++ b/queries/images/images.js
@@ -38,6 +38,14 @@ module.exports = {
 
             return result;
         },
+        getUnlabeledImages: async function (projectPath) {
+            const db = getDbClient(projectPath);
+            const query =
+                "SELECT * FROM Images WHERE IName NOT IN (SELECT IName FROM Labels)";
+            const result = await db.all(query);
+
+            return result;
+        },
         updateImageName: async function (projectPath, oldName, newName) {
             const db = getDbClient(projectPath);
             const query = "UPDATE Images SET IName = ? WHERE IName = ?";

--- a/routes/pages/getYoloXTrainingSettingsPage.js
+++ b/routes/pages/getYoloXTrainingSettingsPage.js
@@ -1,4 +1,5 @@
 const queries = require("../../queries/queries");
+const UNLABELED_CLASS = require("../../utils/unlabeledClass");
 
 async function getYoloXInferencePage(req, res) {
     global.logger.debug("get yolo (ultralytics) X training Setting Page");
@@ -174,6 +175,22 @@ async function getYoloXInferencePage(req, res) {
             labelCount: classLabelCounts[cls.CName] || 0,
             imageCount: classImageCounts[cls.CName] || 0,
         });
+    });
+
+    // Unlabeled images aren't a row in Classes, but training can use them as
+    // background/negative examples, so surface them as a selectable pseudo-class
+    // alongside the real ones instead of always silently including them.
+    var unlabeledImageCount = 0;
+    try {
+        var unlabeledResult = await queries.project.getUnlabeledImages(project_path);
+        unlabeledImageCount = (unlabeledResult && unlabeledResult.rows) ? unlabeledResult.rows.length : 0;
+    } catch (err) {
+        global.logger.error(err);
+    }
+    results2.push({
+        CName: UNLABELED_CLASS,
+        labelCount: 0,
+        imageCount: unlabeledImageCount,
     });
 
     var acc = await db.allAsync(
@@ -412,6 +429,7 @@ async function getYoloXInferencePage(req, res) {
         PDescription: results1.PDescription,
         AutoSave: results1.AutoSave,
         classes: results2,
+        unlabeledClass: UNLABELED_CLASS,
         logs: log_files,
         err_file: err_file,
         err_contents: err,

--- a/routes/training/yoloRun.js
+++ b/routes/training/yoloRun.js
@@ -6,6 +6,7 @@ const probe = require("probe-image-size");
 const os = require("os");
 const sharp = require("sharp");
 const formatRunOptionsHeader = require("../../utils/formatRunOptionsHeader");
+const UNLABELED_CLASS = require("../../utils/unlabeledClass");
 
 // Function to detect the best available device for YOLO training
 async function detectBestDevice() {
@@ -479,9 +480,33 @@ async function yoloRun(req, res) {
         );
     }
 
+    // Whether unlabeled images (no rows in Labels) should be included as
+    // background/negative examples. Absent selected_classes means no filter was
+    // applied at all (legacy behavior: include everything); otherwise it's included
+    // only if the "Unlabeled" pseudo-class checkbox was checked.
+    const includeUnlabeled =
+        !selectedClassesList ||
+        selectedClassesList.length === 0 ||
+        selectedClassesList.includes(UNLABELED_CLASS);
+
     // Parse maximum image clamping
     let maxImages = parseInt(req.body.max_images || req.body.maxImages, 10);
     let targetImages = existingImages.rows;
+
+    if (!includeUnlabeled && ["detect", "segment", "obb"].includes(yoloTask)) {
+        try {
+            const unlabeledResult = await queries.project.getUnlabeledImages(projectPath);
+            const unlabeledImageNames = new Set(
+                (unlabeledResult.rows || []).map((row) => row.IName),
+            );
+            targetImages = targetImages.filter(
+                (img) => !unlabeledImageNames.has(img.IName),
+            );
+        } catch (err) {
+            global.logger.error(err);
+        }
+    }
+
     if (Number.isFinite(maxImages) && maxImages > 0 && maxImages < targetImages.length) {
         targetImages = targetImages.slice(0, maxImages);
     }
@@ -888,6 +913,7 @@ async function yoloRun(req, res) {
         val_percent: valPct,
         test_percent: testPct,
         selected_classes: selectedClassesList ? selectedClassesList.join(", ") : null,
+        include_unlabeled: includeUnlabeled,
         max_images: Number.isFinite(maxImages) ? maxImages : null,
         batch,
         subdiv,

--- a/tests/integration/yoloRun.test.js
+++ b/tests/integration/yoloRun.test.js
@@ -25,10 +25,12 @@ jest.mock('../../queries/queries', () => ({
     getAllImages: jest.fn(),
     getAllClasses: jest.fn(),
     getLabelsForImageName: jest.fn(),
+    getUnlabeledImages: jest.fn(),
   },
 }));
 
 const app = require('../../app');
+const UNLABELED_CLASS = require('../../utils/unlabeledClass');
 
 describe('YOLO Run API', () => {
   beforeEach(() => {
@@ -63,6 +65,10 @@ describe('YOLO Run API', () => {
         { LID: 2, CName: 'car', X: 50, Y: 60, W: 70, H: 80 },
       ],
     });
+
+    queries.project.getUnlabeledImages.mockResolvedValue({
+      rows: [{ IName: 'img9.jpg' }, { IName: 'img10.jpg' }],
+    });
   });
 
   test('POST /yolo-run accepts class subset selection, max image clamping, and train:val:test split ratios', async () => {
@@ -92,5 +98,70 @@ describe('YOLO Run API', () => {
 
     expect(response.status).toBe(200);
     expect(response.body).toEqual({ Success: 'YOLO Training Started' });
+  });
+
+  test('excludes unlabeled images from training when the Unlabeled pseudo-class is not selected', async () => {
+    const readNames = [];
+    jest.spyOn(fs, 'readFileSync').mockImplementation((p) => {
+      readNames.push(path.basename(p));
+      return Buffer.from('fake image content');
+    });
+    jest.spyOn(fs, 'writeFileSync').mockImplementation(() => {});
+    jest.spyOn(fs, 'appendFile').mockImplementation((p, data, cb) => { if (cb) cb(null); });
+    jest.spyOn(fs, 'writeFile').mockImplementation((p, data, cb) => { if (cb) cb(null); });
+    jest.spyOn(fs, 'copyFile').mockImplementation((src, dest, cb) => { if (cb) cb(null); });
+    jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+    jest.spyOn(fs.promises, 'symlink').mockResolvedValue();
+
+    const response = await request(app)
+      .post('/yolo-run')
+      .set('Cookie', ['Username=testuser'])
+      .send({
+        PName: 'testproj',
+        Admin: 'testuser',
+        yolo_task: 'detect',
+        selected_classes: JSON.stringify(['car', 'person', 'dog']),
+        TrainingPercent: 70,
+        weights: 'best.pt',
+        yolovx_path: '/usr/local/bin/yolo',
+      });
+
+    expect(response.status).toBe(200);
+    expect(queries.project.getUnlabeledImages).toHaveBeenCalledWith(
+      expect.stringContaining('testuser-testproj'),
+    );
+    expect(readNames).toEqual(expect.arrayContaining(['img1.jpg', 'img8.jpg']));
+    expect(readNames).not.toEqual(expect.arrayContaining(['img9.jpg', 'img10.jpg']));
+  });
+
+  test('includes unlabeled images as background examples when the Unlabeled pseudo-class is selected', async () => {
+    const readNames = [];
+    jest.spyOn(fs, 'readFileSync').mockImplementation((p) => {
+      readNames.push(path.basename(p));
+      return Buffer.from('fake image content');
+    });
+    jest.spyOn(fs, 'writeFileSync').mockImplementation(() => {});
+    jest.spyOn(fs, 'appendFile').mockImplementation((p, data, cb) => { if (cb) cb(null); });
+    jest.spyOn(fs, 'writeFile').mockImplementation((p, data, cb) => { if (cb) cb(null); });
+    jest.spyOn(fs, 'copyFile').mockImplementation((src, dest, cb) => { if (cb) cb(null); });
+    jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+    jest.spyOn(fs.promises, 'symlink').mockResolvedValue();
+
+    const response = await request(app)
+      .post('/yolo-run')
+      .set('Cookie', ['Username=testuser'])
+      .send({
+        PName: 'testproj',
+        Admin: 'testuser',
+        yolo_task: 'detect',
+        selected_classes: JSON.stringify(['car', 'person', 'dog', UNLABELED_CLASS]),
+        TrainingPercent: 70,
+        weights: 'best.pt',
+        yolovx_path: '/usr/local/bin/yolo',
+      });
+
+    expect(response.status).toBe(200);
+    expect(queries.project.getUnlabeledImages).not.toHaveBeenCalled();
+    expect(readNames).toEqual(expect.arrayContaining(['img9.jpg', 'img10.jpg']));
   });
 });

--- a/tests/integration/yoloXTrainingSettingsClassCounts.test.js
+++ b/tests/integration/yoloXTrainingSettingsClassCounts.test.js
@@ -7,6 +7,7 @@
 jest.mock('../../queries/queries', () => ({
   project: {
     getClassImageCounts: jest.fn(),
+    getUnlabeledImages: jest.fn(),
   },
 }));
 
@@ -96,7 +97,7 @@ describe('GET /yolo/yolovXTrainingSettings - per-class image counts', () => {
     return { req, res };
   }
 
-  it('attaches imageCount to each class from queries.project.getClassImageCounts, keyed by CName', async () => {
+  it('attaches imageCount to each class from queries.project.getClassImageCounts, keyed by CName, and appends an Unlabeled pseudo-class', async () => {
     queries.project.getClassImageCounts.mockResolvedValue({
       success: true,
       rows: [
@@ -105,11 +106,17 @@ describe('GET /yolo/yolovXTrainingSettings - per-class image counts', () => {
         // no row for 'unlabeled_class' -- must default to 0, not be dropped or crash
       ],
     });
+    queries.project.getUnlabeledImages.mockResolvedValue({
+      rows: [{ IName: 'a.jpg' }, { IName: 'b.jpg' }, { IName: 'c.jpg' }],
+    });
 
     const { req, res } = makeReqRes();
     await expect(getYoloXTrainingSettingsPage(req, res)).resolves.not.toThrow();
 
     expect(queries.project.getClassImageCounts).toHaveBeenCalledWith(
+      expect.stringContaining('testuser-test-project'),
+    );
+    expect(queries.project.getUnlabeledImages).toHaveBeenCalledWith(
       expect.stringContaining('testuser-test-project'),
     );
     expect(res.render).toHaveBeenCalledWith(
@@ -119,13 +126,16 @@ describe('GET /yolo/yolovXTrainingSettings - per-class image counts', () => {
           expect.objectContaining({ CName: 'person', imageCount: 42 }),
           expect.objectContaining({ CName: 'car', imageCount: 7 }),
           expect.objectContaining({ CName: 'unlabeled_class', imageCount: 0 }),
+          expect.objectContaining({ CName: '__UNLABELED__', imageCount: 3 }),
         ],
+        unlabeledClass: '__UNLABELED__',
       }),
     );
   });
 
-  it('defaults every class to imageCount 0 and still renders when the count query fails', async () => {
+  it('defaults every class and the Unlabeled pseudo-class to imageCount 0 and still renders when the count queries fail', async () => {
     queries.project.getClassImageCounts.mockRejectedValue(new Error('db unavailable'));
+    queries.project.getUnlabeledImages.mockRejectedValue(new Error('db unavailable'));
 
     const { req, res } = makeReqRes();
     await expect(getYoloXTrainingSettingsPage(req, res)).resolves.not.toThrow();
@@ -137,6 +147,7 @@ describe('GET /yolo/yolovXTrainingSettings - per-class image counts', () => {
           expect.objectContaining({ CName: 'person', imageCount: 0 }),
           expect.objectContaining({ CName: 'car', imageCount: 0 }),
           expect.objectContaining({ CName: 'unlabeled_class', imageCount: 0 }),
+          expect.objectContaining({ CName: '__UNLABELED__', imageCount: 0 }),
         ],
       }),
     );

--- a/views/training/yolovXTrainingSettings.ejs
+++ b/views/training/yolovXTrainingSettings.ejs
@@ -158,7 +158,7 @@
 										<!-- Class Subset Selection -->
 										<div class="form-group col-12 p-3 mb-3 border rounded" style="background-color: #f8f9fa;">
 											<h5><label>Class Subset Selection</label></h5>
-											<p class="text-muted small">Select which classes to include in training:</p>
+											<p class="text-muted small">Select which classes to include in training. "Unlabeled" trains on images with no labels as background/negative examples:</p>
 											<div class="mb-2">
 												<button type="button" class="btn btn-sm btn-outline-primary" id="selectAllClasses">Select All</button>
 												<button type="button" class="btn btn-sm btn-outline-secondary" id="deselectAllClasses">Deselect All</button>
@@ -172,7 +172,7 @@
 													<% for (var i = 0; i < classes.length; i++) { %>
 														<div class="form-check form-check-inline mr-3 my-1">
 															<input class="form-check-input class-checkbox" type="checkbox" name="selected_classes" id="class_<%= i %>" value="<%= classes[i].CName %>" data-image-count="<%= classes[i].imageCount || 0 %>" checked>
-															<label class="form-check-label" for="class_<%= i %>"><%= classes[i].CName %> <span class="text-muted small">(<%= classes[i].imageCount || 0 %> images)</span></label>
+															<label class="form-check-label" for="class_<%= i %>"><%= classes[i].CName === unlabeledClass ? 'Unlabeled' : classes[i].CName %> <span class="text-muted small">(<%= classes[i].imageCount || 0 %> images)</span></label>
 														</div>
 													<% } %>
 												<% } else { %>


### PR DESCRIPTION
Previously unlabeled images were always silently pulled into YOLO detect/segment/obb training runs as background examples, with no way to opt out, and no way to see the option at all in the Class Subset Selection UI. Surface "Unlabeled" as a checkbox alongside real classes on the training settings page (backed by a new
queries.project.getUnlabeledImages) and gate their inclusion in routes/training/yoloRun.js on that checkbox instead of including them unconditionally.